### PR TITLE
added contexts that allows for external tracing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/golang:1.8
+      - image: circleci/golang:1.10
     steps:
       - checkout
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.0.0] - 2018-07-11
+### Changed
+- Now each request method takes a context, see example/main.go for an example
+
 ## [0.0.2] - 2018-07-02
 ### Added
 - GetDiscounts

--- a/client.go
+++ b/client.go
@@ -133,9 +133,7 @@ func (client *Client) Do(ctx context.Context, req *Request) (resp *http.Response
 		return
 	}
 	r.Header = req.Header
-	if ctx != nil {
-		r = r.WithContext(ctx)
-	}
+	r = r.WithContext(ctx)
 
 	resp, err = client.HTTPClient.Do(r)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -108,7 +108,7 @@ func (client *Client) setHeaders(r *Request) error {
 }
 
 // Do makes a request to the API
-func (client *Client) Do(req *Request) (resp *http.Response, err error) {
+func (client *Client) Do(ctx context.Context, req *Request) (resp *http.Response, err error) {
 	u, err := client.getURL(req)
 	if err != nil {
 		return
@@ -133,8 +133,8 @@ func (client *Client) Do(req *Request) (resp *http.Response, err error) {
 		return
 	}
 	r.Header = req.Header
-	if req.Context != nil {
-		r = r.WithContext(req.Context)
+	if ctx != nil {
+		r = r.WithContext(ctx)
 	}
 
 	resp, err = client.HTTPClient.Do(r)
@@ -149,8 +149,8 @@ func (client *Client) Do(req *Request) (resp *http.Response, err error) {
 
 // Test tests the API connection returning a User on success
 func (client *Client) Test(ctx context.Context) (*User, error) {
-	req := NewRequest(ctx, "GET", "test.v1", nil)
-	resp, err := client.Do(req)
+	req := NewRequest("GET", "test.v1", nil)
+	resp, err := client.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -331,12 +331,12 @@ func (params *ListEventsParams) Params() map[string]string {
 
 // ListEvents returns a paginated slice of Events from the API.
 func (client *Client) ListEvents(ctx context.Context, params *ListEventsParams) (*ListEventsResults, error) {
-	req := NewRequest(ctx, http.MethodGet, "events.v1", nil)
+	req := NewRequest(http.MethodGet, "events.v1", nil)
 	if params != nil {
 		req.SetValues(params.Params())
 	}
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -385,14 +385,14 @@ type getEventResults struct {
 
 // GetEvents returns a map of events index by event ID from the API.
 func (client *Client) GetEvents(ctx context.Context, eventIDs []string, params *UniversalParams) (map[string]*Event, error) {
-	req := NewRequest(ctx, http.MethodGet, "events_by_id.v1", nil)
+	req := NewRequest(http.MethodGet, "events_by_id.v1", nil)
 	if params != nil {
 		req.SetValues(params.Universal())
 	}
 
 	req.SetValues(map[string]string{"event_id_list": strings.Join(eventIDs, ",")})
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -467,12 +467,12 @@ func (params *ListPerformancesParams) Params() map[string]string {
 
 // ListPerformances fetches a slice of performances from the API
 func (client *Client) ListPerformances(ctx context.Context, params *ListPerformancesParams) (*ListPerformancesResults, error) {
-	req := NewRequest(ctx, http.MethodGet, "performances.v1", nil)
+	req := NewRequest(http.MethodGet, "performances.v1", nil)
 	if params != nil {
 		req.SetValues(params.Params())
 	}
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -489,13 +489,13 @@ func (client *Client) ListPerformances(ctx context.Context, params *ListPerforma
 
 // GetAvailability fetches availability for a performce from the API
 func (client *Client) GetAvailability(ctx context.Context, perf string, params *GetAvailabilityParams) (*AvailabilityResult, error) {
-	req := NewRequest(ctx, http.MethodGet, "availability.v1", nil)
+	req := NewRequest(http.MethodGet, "availability.v1", nil)
 	if params != nil {
 		req.SetValues(params.Params())
 	}
 	req.Values.Set("perf_id", perf)
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -512,7 +512,7 @@ func (client *Client) GetAvailability(ctx context.Context, perf string, params *
 
 // GetDiscounts fetches the Discounts for a particular performance, ticket type and price band from the API
 func (client *Client) GetDiscounts(ctx context.Context, perf string, ticketTypeCode string, priceBandCode string, params *UniversalParams) (*DiscountsResult, error) {
-	req := NewRequest(ctx, http.MethodGet, "discounts.v1", nil)
+	req := NewRequest(http.MethodGet, "discounts.v1", nil)
 	if params != nil {
 		req.SetValues(params.Universal())
 	}
@@ -520,7 +520,7 @@ func (client *Client) GetDiscounts(ctx context.Context, perf string, ticketTypeC
 	req.Values.Set("ticket_type_code", ticketTypeCode)
 	req.Values.Set("price_band_code", priceBandCode)
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -538,12 +538,12 @@ func (client *Client) GetDiscounts(ctx context.Context, perf string, ticketTypeC
 // GetSources fetches the available sources (a.k.a. backend systems) from the
 // API
 func (client *Client) GetSources(ctx context.Context, params *UniversalParams) (*SourcesResult, error) {
-	req := NewRequest(ctx, http.MethodGet, "sources.v1", nil)
+	req := NewRequest(http.MethodGet, "sources.v1", nil)
 	if params != nil {
 		req.SetValues(params.Universal())
 	}
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -563,13 +563,13 @@ func (client *Client) GetSources(ctx context.Context, params *UniversalParams) (
 // GetSendMethods fetches the available send methods for a performance from the
 // API
 func (client *Client) GetSendMethods(ctx context.Context, perf string, params *UniversalParams) (*SendMethodsResults, error) {
-	req := NewRequest(ctx, http.MethodGet, "send_methods.v1", nil)
+	req := NewRequest(http.MethodGet, "send_methods.v1", nil)
 	if params != nil {
 		req.SetValues(params.Universal())
 	}
 	req.Values.Set("perf_id", perf)
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -586,9 +586,9 @@ func (client *Client) GetSendMethods(ctx context.Context, perf string, params *U
 
 // MakeReservation places a hold on products in the inventory via the API
 func (client *Client) MakeReservation(ctx context.Context, params *MakeReservationParams) (*ReservationResult, error) {
-	req := NewRequest(ctx, http.MethodPost, "reserve.v1", params.Params())
+	req := NewRequest(http.MethodPost, "reserve.v1", params.Params())
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -626,9 +626,9 @@ func (params *TransactionParams) Params() map[string]string {
 // ReleaseReservation makes a best effort attempt to release any reservations
 // made on backend systems for a transaction.
 func (client *Client) ReleaseReservation(ctx context.Context, params *TransactionParams) (success bool, err error) {
-	req := NewRequest(ctx, http.MethodPost, "release.v1", params.Params())
+	req := NewRequest(http.MethodPost, "release.v1", params.Params())
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(ctx, req)
 	if err != nil {
 		return false, err
 	}
@@ -691,9 +691,9 @@ func (params *MakePurchaseParams) Params() map[string]string {
 // MakePurchase attempts to purchase a previously reserved transaction via the
 // API
 func (client *Client) MakePurchase(ctx context.Context, params *MakePurchaseParams) (*MakePurchaseResult, error) {
-	req := NewRequest(ctx, http.MethodPost, "purchase.v1", params.Params())
+	req := NewRequest(http.MethodPost, "purchase.v1", params.Params())
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -710,12 +710,12 @@ func (client *Client) MakePurchase(ctx context.Context, params *MakePurchasePara
 
 // GetStatus retrieves the transaction from the API
 func (client *Client) GetStatus(ctx context.Context, params *TransactionParams) (*StatusResult, error) {
-	req := NewRequest(ctx, http.MethodGet, "status.v1", nil)
+	req := NewRequest(http.MethodGet, "status.v1", nil)
 	if params != nil {
 		req.SetValues(params.Params())
 	}
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@ package ticketswitch
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -132,6 +133,9 @@ func (client *Client) Do(req *Request) (resp *http.Response, err error) {
 		return
 	}
 	r.Header = req.Header
+	if req.Context != nil {
+		r = r.WithContext(req.Context)
+	}
 
 	resp, err = client.HTTPClient.Do(r)
 	if err != nil {
@@ -178,6 +182,7 @@ type UniversalParams struct {
 	SourceInfo                   bool
 	TrackingID                   string
 	Misc                         map[string]string
+	Context                      context.Context
 }
 
 // Universal returns the parameters as a map of parameters
@@ -330,6 +335,7 @@ func (client *Client) ListEvents(params *ListEventsParams) (*ListEventsResults, 
 	req := NewRequest(http.MethodGet, "events.v1", nil)
 	if params != nil {
 		req.SetValues(params.Params())
+		req.Context = params.UniversalParams.Context
 	}
 
 	resp, err := client.Do(req)
@@ -384,6 +390,7 @@ func (client *Client) GetEvents(eventIDs []string, params *UniversalParams) (map
 	req := NewRequest(http.MethodGet, "events_by_id.v1", nil)
 	if params != nil {
 		req.SetValues(params.Universal())
+		req.Context = params.Context
 	}
 
 	req.SetValues(map[string]string{"event_id_list": strings.Join(eventIDs, ",")})
@@ -466,6 +473,7 @@ func (client *Client) ListPerformances(params *ListPerformancesParams) (*ListPer
 	req := NewRequest(http.MethodGet, "performances.v1", nil)
 	if params != nil {
 		req.SetValues(params.Params())
+		req.Context = params.UniversalParams.Context
 	}
 
 	resp, err := client.Do(req)
@@ -488,6 +496,7 @@ func (client *Client) GetAvailability(perf string, params *GetAvailabilityParams
 	req := NewRequest(http.MethodGet, "availability.v1", nil)
 	if params != nil {
 		req.SetValues(params.Params())
+		req.Context = params.UniversalParams.Context
 	}
 	req.Values.Set("perf_id", perf)
 
@@ -511,6 +520,7 @@ func (client *Client) GetDiscounts(perf string, ticketTypeCode string, priceBand
 	req := NewRequest(http.MethodGet, "discounts.v1", nil)
 	if params != nil {
 		req.SetValues(params.Universal())
+		req.Context = params.Context
 	}
 	req.Values.Set("perf_id", perf)
 	req.Values.Set("ticket_type_code", ticketTypeCode)
@@ -537,6 +547,7 @@ func (client *Client) GetSources(params *UniversalParams) (*SourcesResult, error
 	req := NewRequest(http.MethodGet, "sources.v1", nil)
 	if params != nil {
 		req.SetValues(params.Universal())
+		req.Context = params.Context
 	}
 
 	resp, err := client.Do(req)
@@ -562,6 +573,7 @@ func (client *Client) GetSendMethods(perf string, params *UniversalParams) (*Sen
 	req := NewRequest(http.MethodGet, "send_methods.v1", nil)
 	if params != nil {
 		req.SetValues(params.Universal())
+		req.Context = params.Context
 	}
 	req.Values.Set("perf_id", perf)
 
@@ -583,6 +595,7 @@ func (client *Client) GetSendMethods(perf string, params *UniversalParams) (*Sen
 // MakeReservation places a hold on products in the inventory via the API
 func (client *Client) MakeReservation(params *MakeReservationParams) (*ReservationResult, error) {
 	req := NewRequest(http.MethodPost, "reserve.v1", params.Params())
+	req.Context = params.UniversalParams.Context
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -623,6 +636,7 @@ func (params *TransactionParams) Params() map[string]string {
 // made on backend systems for a transaction.
 func (client *Client) ReleaseReservation(params *TransactionParams) (success bool, err error) {
 	req := NewRequest(http.MethodPost, "release.v1", params.Params())
+	req.Context = params.UniversalParams.Context
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -688,6 +702,7 @@ func (params *MakePurchaseParams) Params() map[string]string {
 // API
 func (client *Client) MakePurchase(params *MakePurchaseParams) (*MakePurchaseResult, error) {
 	req := NewRequest(http.MethodPost, "purchase.v1", params.Params())
+	req.Context = params.UniversalParams.Context
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -709,6 +724,7 @@ func (client *Client) GetStatus(params *TransactionParams) (*StatusResult, error
 	req := NewRequest(http.MethodGet, "status.v1", nil)
 	if params != nil {
 		req.SetValues(params.Params())
+		req.Context = params.UniversalParams.Context
 	}
 
 	resp, err := client.Do(req)

--- a/client.go
+++ b/client.go
@@ -148,8 +148,8 @@ func (client *Client) Do(req *Request) (resp *http.Response, err error) {
 }
 
 // Test tests the API connection returning a User on success
-func (client *Client) Test() (*User, error) {
-	req := NewRequest("GET", "test.v1", nil)
+func (client *Client) Test(ctx context.Context) (*User, error) {
+	req := NewRequest(ctx, "GET", "test.v1", nil)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -182,7 +182,6 @@ type UniversalParams struct {
 	SourceInfo                   bool
 	TrackingID                   string
 	Misc                         map[string]string
-	Context                      context.Context
 }
 
 // Universal returns the parameters as a map of parameters
@@ -331,11 +330,10 @@ func (params *ListEventsParams) Params() map[string]string {
 }
 
 // ListEvents returns a paginated slice of Events from the API.
-func (client *Client) ListEvents(params *ListEventsParams) (*ListEventsResults, error) {
-	req := NewRequest(http.MethodGet, "events.v1", nil)
+func (client *Client) ListEvents(ctx context.Context, params *ListEventsParams) (*ListEventsResults, error) {
+	req := NewRequest(ctx, http.MethodGet, "events.v1", nil)
 	if params != nil {
 		req.SetValues(params.Params())
-		req.Context = params.UniversalParams.Context
 	}
 
 	resp, err := client.Do(req)
@@ -386,11 +384,10 @@ type getEventResults struct {
 }
 
 // GetEvents returns a map of events index by event ID from the API.
-func (client *Client) GetEvents(eventIDs []string, params *UniversalParams) (map[string]*Event, error) {
-	req := NewRequest(http.MethodGet, "events_by_id.v1", nil)
+func (client *Client) GetEvents(ctx context.Context, eventIDs []string, params *UniversalParams) (map[string]*Event, error) {
+	req := NewRequest(ctx, http.MethodGet, "events_by_id.v1", nil)
 	if params != nil {
 		req.SetValues(params.Universal())
-		req.Context = params.Context
 	}
 
 	req.SetValues(map[string]string{"event_id_list": strings.Join(eventIDs, ",")})
@@ -420,8 +417,8 @@ func (client *Client) GetEvents(eventIDs []string, params *UniversalParams) (map
 var ErrEventNotFound = errors.New("ticketswitch: event not found")
 
 // GetEvent returns an Event fetched from the API
-func (client *Client) GetEvent(eventID string, params *UniversalParams) (*Event, error) {
-	events, err := client.GetEvents([]string{eventID}, params)
+func (client *Client) GetEvent(ctx context.Context, eventID string, params *UniversalParams) (*Event, error) {
+	events, err := client.GetEvents(ctx, []string{eventID}, params)
 
 	if err != nil {
 		return nil, err
@@ -469,11 +466,10 @@ func (params *ListPerformancesParams) Params() map[string]string {
 }
 
 // ListPerformances fetches a slice of performances from the API
-func (client *Client) ListPerformances(params *ListPerformancesParams) (*ListPerformancesResults, error) {
-	req := NewRequest(http.MethodGet, "performances.v1", nil)
+func (client *Client) ListPerformances(ctx context.Context, params *ListPerformancesParams) (*ListPerformancesResults, error) {
+	req := NewRequest(ctx, http.MethodGet, "performances.v1", nil)
 	if params != nil {
 		req.SetValues(params.Params())
-		req.Context = params.UniversalParams.Context
 	}
 
 	resp, err := client.Do(req)
@@ -492,11 +488,10 @@ func (client *Client) ListPerformances(params *ListPerformancesParams) (*ListPer
 }
 
 // GetAvailability fetches availability for a performce from the API
-func (client *Client) GetAvailability(perf string, params *GetAvailabilityParams) (*AvailabilityResult, error) {
-	req := NewRequest(http.MethodGet, "availability.v1", nil)
+func (client *Client) GetAvailability(ctx context.Context, perf string, params *GetAvailabilityParams) (*AvailabilityResult, error) {
+	req := NewRequest(ctx, http.MethodGet, "availability.v1", nil)
 	if params != nil {
 		req.SetValues(params.Params())
-		req.Context = params.UniversalParams.Context
 	}
 	req.Values.Set("perf_id", perf)
 
@@ -516,11 +511,10 @@ func (client *Client) GetAvailability(perf string, params *GetAvailabilityParams
 }
 
 // GetDiscounts fetches the Discounts for a particular performance, ticket type and price band from the API
-func (client *Client) GetDiscounts(perf string, ticketTypeCode string, priceBandCode string, params *UniversalParams) (*DiscountsResult, error) {
-	req := NewRequest(http.MethodGet, "discounts.v1", nil)
+func (client *Client) GetDiscounts(ctx context.Context, perf string, ticketTypeCode string, priceBandCode string, params *UniversalParams) (*DiscountsResult, error) {
+	req := NewRequest(ctx, http.MethodGet, "discounts.v1", nil)
 	if params != nil {
 		req.SetValues(params.Universal())
-		req.Context = params.Context
 	}
 	req.Values.Set("perf_id", perf)
 	req.Values.Set("ticket_type_code", ticketTypeCode)
@@ -543,11 +537,10 @@ func (client *Client) GetDiscounts(perf string, ticketTypeCode string, priceBand
 
 // GetSources fetches the available sources (a.k.a. backend systems) from the
 // API
-func (client *Client) GetSources(params *UniversalParams) (*SourcesResult, error) {
-	req := NewRequest(http.MethodGet, "sources.v1", nil)
+func (client *Client) GetSources(ctx context.Context, params *UniversalParams) (*SourcesResult, error) {
+	req := NewRequest(ctx, http.MethodGet, "sources.v1", nil)
 	if params != nil {
 		req.SetValues(params.Universal())
-		req.Context = params.Context
 	}
 
 	resp, err := client.Do(req)
@@ -569,11 +562,10 @@ func (client *Client) GetSources(params *UniversalParams) (*SourcesResult, error
 
 // GetSendMethods fetches the available send methods for a performance from the
 // API
-func (client *Client) GetSendMethods(perf string, params *UniversalParams) (*SendMethodsResults, error) {
-	req := NewRequest(http.MethodGet, "send_methods.v1", nil)
+func (client *Client) GetSendMethods(ctx context.Context, perf string, params *UniversalParams) (*SendMethodsResults, error) {
+	req := NewRequest(ctx, http.MethodGet, "send_methods.v1", nil)
 	if params != nil {
 		req.SetValues(params.Universal())
-		req.Context = params.Context
 	}
 	req.Values.Set("perf_id", perf)
 
@@ -593,9 +585,8 @@ func (client *Client) GetSendMethods(perf string, params *UniversalParams) (*Sen
 }
 
 // MakeReservation places a hold on products in the inventory via the API
-func (client *Client) MakeReservation(params *MakeReservationParams) (*ReservationResult, error) {
-	req := NewRequest(http.MethodPost, "reserve.v1", params.Params())
-	req.Context = params.UniversalParams.Context
+func (client *Client) MakeReservation(ctx context.Context, params *MakeReservationParams) (*ReservationResult, error) {
+	req := NewRequest(ctx, http.MethodPost, "reserve.v1", params.Params())
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -634,9 +625,8 @@ func (params *TransactionParams) Params() map[string]string {
 
 // ReleaseReservation makes a best effort attempt to release any reservations
 // made on backend systems for a transaction.
-func (client *Client) ReleaseReservation(params *TransactionParams) (success bool, err error) {
-	req := NewRequest(http.MethodPost, "release.v1", params.Params())
-	req.Context = params.UniversalParams.Context
+func (client *Client) ReleaseReservation(ctx context.Context, params *TransactionParams) (success bool, err error) {
+	req := NewRequest(ctx, http.MethodPost, "release.v1", params.Params())
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -700,9 +690,8 @@ func (params *MakePurchaseParams) Params() map[string]string {
 
 // MakePurchase attempts to purchase a previously reserved transaction via the
 // API
-func (client *Client) MakePurchase(params *MakePurchaseParams) (*MakePurchaseResult, error) {
-	req := NewRequest(http.MethodPost, "purchase.v1", params.Params())
-	req.Context = params.UniversalParams.Context
+func (client *Client) MakePurchase(ctx context.Context, params *MakePurchaseParams) (*MakePurchaseResult, error) {
+	req := NewRequest(ctx, http.MethodPost, "purchase.v1", params.Params())
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -720,11 +709,10 @@ func (client *Client) MakePurchase(params *MakePurchaseParams) (*MakePurchaseRes
 }
 
 // GetStatus retrieves the transaction from the API
-func (client *Client) GetStatus(params *TransactionParams) (*StatusResult, error) {
-	req := NewRequest(http.MethodGet, "status.v1", nil)
+func (client *Client) GetStatus(ctx context.Context, params *TransactionParams) (*StatusResult, error) {
+	req := NewRequest(ctx, http.MethodGet, "status.v1", nil)
 	if params != nil {
 		req.SetValues(params.Params())
-		req.Context = params.UniversalParams.Context
 	}
 
 	resp, err := client.Do(req)

--- a/client_test.go
+++ b/client_test.go
@@ -1272,7 +1272,7 @@ func TestMakeReservationFailure(t *testing.T) {
 		assert.Equal(t, results.Status, "reserved")
 		assert.Equal(t, results.Trolley.TransactionUUID, "U-8841ADC8-5F69-11E8-A0DD-AC1F6B466128-EC1A0BEE-LDNX")
 		assert.Equal(t, len(results.Trolley.Bundles), results.Trolley.BundleCount)
-		assert.Equal(t, results.Trolley.Bundles[0].TotalCost, decimal.NewFromFloat(20))
+		assert.Equal(t, results.Trolley.Bundles[0].TotalCost, decimal.NewFromFloat(20.0))
 		assert.Equal(t, len(results.Trolley.Bundles[0].Orders), 0)
 		assert.Equal(t, len(results.UnreservedOrders), 1)
 		assert.Equal(t, results.UnreservedOrders[0].ItemNumber, 1)

--- a/client_test.go
+++ b/client_test.go
@@ -1272,7 +1272,7 @@ func TestMakeReservationFailure(t *testing.T) {
 		assert.Equal(t, results.Status, "reserved")
 		assert.Equal(t, results.Trolley.TransactionUUID, "U-8841ADC8-5F69-11E8-A0DD-AC1F6B466128-EC1A0BEE-LDNX")
 		assert.Equal(t, len(results.Trolley.Bundles), results.Trolley.BundleCount)
-		assert.EqualValues(t, results.Trolley.Bundles[0].TotalCost, decimal.NewFromFloat(20.0))
+		assert.True(t, results.Trolley.Bundles[0].TotalCost.Equal(decimal.NewFromFloat(20)))
 		assert.Equal(t, len(results.Trolley.Bundles[0].Orders), 0)
 		assert.Equal(t, len(results.UnreservedOrders), 1)
 		assert.Equal(t, results.UnreservedOrders[0].ItemNumber, 1)

--- a/client_test.go
+++ b/client_test.go
@@ -1,6 +1,7 @@
 package ticketswitch
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -18,7 +19,7 @@ func TestGetURL(t *testing.T) {
 	}
 	client := NewClient(config)
 
-	req := NewRequest("GET", "events.v1", nil)
+	req := NewRequest(context.Background(), "GET", "events.v1", nil)
 	u, err := client.getURL(req)
 	if assert.Nil(t, err) {
 		assert.Equal(t, u.String(), "https://super.awesome.tickets/f13/events.v1")
@@ -31,7 +32,7 @@ func TestGetURL_bad(t *testing.T) {
 	}
 	client := NewClient(config)
 
-	req := NewRequest("GET", "events.v1", nil)
+	req := NewRequest(context.Background(), "GET", "events.v1", nil)
 	_, err := client.getURL(req)
 	assert.NotNil(t, err)
 }
@@ -42,7 +43,7 @@ func TestGetURL_with_values(t *testing.T) {
 	}
 	client := NewClient(config)
 
-	req := NewRequest("GET", "events.v1", nil)
+	req := NewRequest(context.Background(), "GET", "events.v1", nil)
 	req.Values.Add("foo", "bar")
 	req.Values.Add("lol", "beans")
 	req.Values.Add("lol", "icoptor")
@@ -60,7 +61,7 @@ func TestGetURL_with_crypto_block(t *testing.T) {
 		User:        "fred_flintstone",
 	}
 	client := NewClient(config)
-	req := NewRequest("GET", "events.v1", nil)
+	req := NewRequest(context.Background(), "GET", "events.v1", nil)
 
 	u, err := client.getURL(req)
 
@@ -82,7 +83,7 @@ func TestGetURL_with_sub_user(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	req := NewRequest("GET", "events.v1", nil)
+	req := NewRequest(context.Background(), "GET", "events.v1", nil)
 
 	u, err := client.getURL(req)
 
@@ -99,7 +100,7 @@ func TestSetHeaders(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	req := NewRequest("GET", "events.v1", nil)
+	req := NewRequest(context.Background(), "GET", "events.v1", nil)
 
 	err := client.setHeaders(req)
 
@@ -154,7 +155,7 @@ func TestDo_post(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	req := NewRequest("POST", "events.v1", map[string]string{"foo": "bar", "lol": "beans"})
+	req := NewRequest(context.Background(), "POST", "events.v1", map[string]string{"foo": "bar", "lol": "beans"})
 
 	resp, err := client.Do(req)
 
@@ -186,7 +187,7 @@ func TestDo_get(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	req := NewRequest("GET", "events.v1", nil)
+	req := NewRequest(context.Background(), "GET", "events.v1", nil)
 
 	resp, err := client.Do(req)
 
@@ -203,7 +204,7 @@ func TestDo_with_bad_base_url(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	req := NewRequest("GET", "events.v1", nil)
+	req := NewRequest(context.Background(), "GET", "events.v1", nil)
 
 	_, err := client.Do(req)
 
@@ -224,7 +225,7 @@ func TestDo_with_header_issues(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	req := NewRequest("GET", "events.v1", nil)
+	req := NewRequest(context.Background(), "GET", "events.v1", nil)
 
 	_, err := client.Do(req)
 
@@ -246,7 +247,7 @@ func TestDo_post_with_unmarshalable_body(t *testing.T) {
 
 	client := NewClient(config)
 	// func cannot be marshalled
-	req := NewRequest("POST", "events.v1", func() { t.Fatal("this should not run") })
+	req := NewRequest(context.Background(), "POST", "events.v1", func() { t.Fatal("this should not run") })
 
 	_, err := client.Do(req)
 
@@ -268,7 +269,7 @@ func TestDo_unrequestable_request(t *testing.T) {
 
 	client := NewClient(config)
 	// unicode in the method is a nono
-	req := NewRequest("£££££", "events.v1", nil)
+	req := NewRequest(context.Background(), "£££££", "events.v1", nil)
 
 	_, err := client.Do(req)
 
@@ -285,7 +286,7 @@ func TestDo_error_when_doing(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	req := NewRequest("POST", "events.v1", nil)
+	req := NewRequest(context.Background(), "POST", "events.v1", nil)
 
 	_, err := client.Do(req)
 
@@ -309,7 +310,7 @@ func TestTest(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	user, err := client.Test()
+	user, err := client.Test(context.Background())
 
 	if assert.Nil(t, err) {
 		assert.Equal(t, "bill", user.ID)
@@ -335,7 +336,7 @@ func TestTest_error(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	user, err := client.Test()
+	user, err := client.Test(context.Background())
 
 	if assert.NotNil(t, err) {
 		assert.Nil(t, user)
@@ -352,7 +353,7 @@ func TestTest_request_error(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	_, err := client.Test()
+	_, err := client.Test(context.Background())
 
 	assert.NotNil(t, err)
 }
@@ -374,7 +375,7 @@ func TestTest_request_read_error(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	_, err := client.Test()
+	_, err := client.Test(context.Background())
 
 	assert.NotNil(t, err)
 }
@@ -395,7 +396,7 @@ func TestTest_request_bad_user_json(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	_, err := client.Test()
+	_, err := client.Test(context.Background())
 
 	assert.NotNil(t, err)
 }
@@ -642,7 +643,7 @@ func TestListEvents(t *testing.T) {
 	params := &ListEventsParams{
 		Keywords: []string{"foo", "bar", "lol"},
 	}
-	results, err := client.ListEvents(params)
+	results, err := client.ListEvents(context.Background(), params)
 
 	if assert.Nil(t, err) {
 		assert.Equal(t, 2, results.PagingStatus.PageLength)
@@ -664,7 +665,7 @@ func TestListEvents_request_error(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	_, err := client.ListEvents(nil)
+	_, err := client.ListEvents(context.Background(), nil)
 
 	assert.NotNil(t, err)
 }
@@ -685,7 +686,7 @@ func TestListEvents_read_error(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	_, err := client.ListEvents(nil)
+	_, err := client.ListEvents(context.Background(), nil)
 
 	assert.NotNil(t, err)
 }
@@ -727,7 +728,7 @@ func TestGetEvents(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	events, err := client.GetEvents([]string{"1AA", "2BB", "3CC"}, nil)
+	events, err := client.GetEvents(context.Background(), []string{"1AA", "2BB", "3CC"}, nil)
 
 	if err != nil {
 		t.Fatal(err)
@@ -771,7 +772,7 @@ func TestGetEvent(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	event, err := client.GetEvent("1AA", nil)
+	event, err := client.GetEvent(context.Background(), "1AA", nil)
 
 	if err != nil {
 		t.Fatal(err)
@@ -851,7 +852,7 @@ func TestListPerformances(t *testing.T) {
 		StartDate: time.Date(2015, 4, 3, 2, 1, 0, 0, time.UTC),
 		EndDate:   time.Date(2015, 6, 7, 8, 9, 0, 0, time.UTC),
 	}
-	results, err := client.ListPerformances(params)
+	results, err := client.ListPerformances(context.Background(), params)
 
 	if assert.Nil(t, err) {
 		assert.True(t, results.HasPerfNames)
@@ -900,7 +901,7 @@ func TestListPerformancesSingleResult(t *testing.T) {
 		StartDate: time.Date(2015, 4, 3, 2, 1, 0, 0, time.UTC),
 		EndDate:   time.Date(2015, 6, 7, 8, 9, 0, 0, time.UTC),
 	}
-	results, err := client.ListPerformances(params)
+	results, err := client.ListPerformances(context.Background(), params)
 
 	if assert.Nil(t, err) {
 		assert.False(t, results.HasPerfNames)
@@ -928,7 +929,7 @@ func TestListPerformances_error(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	user, err := client.ListPerformances(nil)
+	user, err := client.ListPerformances(context.Background(), nil)
 
 	if assert.NotNil(t, err) {
 		assert.Nil(t, user)
@@ -958,7 +959,7 @@ func TestGetAvailability(t *testing.T) {
 	params := GetAvailabilityParams{
 		NumberOfSeats: 2,
 	}
-	results, err := client.GetAvailability("7AA-5", &params)
+	results, err := client.GetAvailability(context.Background(), "7AA-5", &params)
 
 	if assert.Nil(t, err) {
 		assert.NotNil(t, results)
@@ -990,7 +991,7 @@ func TestGetDiscounts(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	results, err := client.GetDiscounts("6IF-C5O", "CIRCLE", "A/pool", nil)
+	results, err := client.GetDiscounts(context.Background(), "6IF-C5O", "CIRCLE", "A/pool", nil)
 
 	if assert.Nil(t, err) {
 		discounts := results.DiscountsHolder.Discounts
@@ -1034,7 +1035,7 @@ func TestGetSources(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	results, err := client.GetSources(nil)
+	results, err := client.GetSources(context.Background(), nil)
 
 	if assert.Nil(t, err) {
 		sources := results.Sources
@@ -1071,7 +1072,7 @@ func TestGetSourcesWithReqSrcInfo(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	results, err := client.GetSources(params)
+	results, err := client.GetSources(context.Background(), params)
 
 	if assert.Nil(t, err) {
 		sources := results.Sources
@@ -1124,7 +1125,7 @@ func TestGetSourcesError(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	results, err := client.GetSources(params)
+	results, err := client.GetSources(context.Background(), params)
 
 	assert.Nil(t, results)
 	assert.Equal(t, err.Error(), "ticketswitch: API error 8: Bad data supplied")
@@ -1151,7 +1152,7 @@ func TestGetSendMethods(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	results, err := client.GetSendMethods("6IF-C30", nil)
+	results, err := client.GetSendMethods(context.Background(), "6IF-C30", nil)
 
 	if assert.Nil(t, err) {
 		assert.Equal(t, results.SourceCode, "ext_test0")
@@ -1199,7 +1200,7 @@ func TestMakeReservation(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	results, err := client.MakeReservation(params)
+	results, err := client.MakeReservation(context.Background(), params)
 
 	if assert.Nil(t, err) {
 		assert.Equal(t, results.AllowedCountries["ad"], "Andorra")
@@ -1253,7 +1254,7 @@ func TestMakeReservationFailure(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	results, err := client.MakeReservation(params)
+	results, err := client.MakeReservation(context.Background(), params)
 
 	if assert.Nil(t, err) {
 		assert.Equal(t, results.AllowedCountries["ad"], "Andorra")
@@ -1315,7 +1316,7 @@ func TestReleaseReservation_success(t *testing.T) {
 	params := &TransactionParams{
 		TransactionUUID: "4df498e9-2daa-4393-a6bb-cc3dfefa7cc1",
 	}
-	success, err := client.ReleaseReservation(params)
+	success, err := client.ReleaseReservation(context.Background(), params)
 	if assert.Nil(t, err) {
 		assert.True(t, success)
 	}
@@ -1337,7 +1338,7 @@ func TestReleaseReservation_failed(t *testing.T) {
 	params := &TransactionParams{
 		TransactionUUID: "4df498e9-2daa-4393-a6bb-cc3dfefa7cc1",
 	}
-	success, err := client.ReleaseReservation(params)
+	success, err := client.ReleaseReservation(context.Background(), params)
 	if assert.Nil(t, err) {
 		assert.False(t, success)
 	}
@@ -1411,7 +1412,7 @@ func TestMakePurchase_success(t *testing.T) {
 	params := &MakePurchaseParams{
 		TransactionUUID: "4df498e9-2daa-4393-a6bb-cc3dfefa7cc1",
 	}
-	result, err := client.MakePurchase(params)
+	result, err := client.MakePurchase(context.Background(), params)
 	if assert.Nil(t, err) {
 		assert.Equal(t, "purchased", result.Status)
 		assert.Nil(t, result.Callout)
@@ -1479,7 +1480,7 @@ func TestGetStatus(t *testing.T) {
 	params := &TransactionParams{
 		TransactionUUID: "4df498e9-2daa-4393-a6bb-cc3dfefa7cc1",
 	}
-	result, err := client.GetStatus(params)
+	result, err := client.GetStatus(context.Background(), params)
 	if assert.Nil(t, err) {
 		assert.Equal(t, "purchased", result.Status)
 		assert.Equal(t, map[string]Currency{

--- a/client_test.go
+++ b/client_test.go
@@ -1272,7 +1272,7 @@ func TestMakeReservationFailure(t *testing.T) {
 		assert.Equal(t, results.Status, "reserved")
 		assert.Equal(t, results.Trolley.TransactionUUID, "U-8841ADC8-5F69-11E8-A0DD-AC1F6B466128-EC1A0BEE-LDNX")
 		assert.Equal(t, len(results.Trolley.Bundles), results.Trolley.BundleCount)
-		assert.Equal(t, results.Trolley.Bundles[0].TotalCost, decimal.NewFromFloat(20.0))
+		assert.EqualValues(t, results.Trolley.Bundles[0].TotalCost, decimal.NewFromFloat(20.0))
 		assert.Equal(t, len(results.Trolley.Bundles[0].Orders), 0)
 		assert.Equal(t, len(results.UnreservedOrders), 1)
 		assert.Equal(t, results.UnreservedOrders[0].ItemNumber, 1)

--- a/client_test.go
+++ b/client_test.go
@@ -19,7 +19,7 @@ func TestGetURL(t *testing.T) {
 	}
 	client := NewClient(config)
 
-	req := NewRequest(context.Background(), "GET", "events.v1", nil)
+	req := NewRequest("GET", "events.v1", nil)
 	u, err := client.getURL(req)
 	if assert.Nil(t, err) {
 		assert.Equal(t, u.String(), "https://super.awesome.tickets/f13/events.v1")
@@ -32,7 +32,7 @@ func TestGetURL_bad(t *testing.T) {
 	}
 	client := NewClient(config)
 
-	req := NewRequest(context.Background(), "GET", "events.v1", nil)
+	req := NewRequest("GET", "events.v1", nil)
 	_, err := client.getURL(req)
 	assert.NotNil(t, err)
 }
@@ -43,7 +43,7 @@ func TestGetURL_with_values(t *testing.T) {
 	}
 	client := NewClient(config)
 
-	req := NewRequest(context.Background(), "GET", "events.v1", nil)
+	req := NewRequest("GET", "events.v1", nil)
 	req.Values.Add("foo", "bar")
 	req.Values.Add("lol", "beans")
 	req.Values.Add("lol", "icoptor")
@@ -61,7 +61,7 @@ func TestGetURL_with_crypto_block(t *testing.T) {
 		User:        "fred_flintstone",
 	}
 	client := NewClient(config)
-	req := NewRequest(context.Background(), "GET", "events.v1", nil)
+	req := NewRequest("GET", "events.v1", nil)
 
 	u, err := client.getURL(req)
 
@@ -83,7 +83,7 @@ func TestGetURL_with_sub_user(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	req := NewRequest(context.Background(), "GET", "events.v1", nil)
+	req := NewRequest("GET", "events.v1", nil)
 
 	u, err := client.getURL(req)
 
@@ -100,7 +100,7 @@ func TestSetHeaders(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	req := NewRequest(context.Background(), "GET", "events.v1", nil)
+	req := NewRequest("GET", "events.v1", nil)
 
 	err := client.setHeaders(req)
 
@@ -155,9 +155,9 @@ func TestDo_post(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	req := NewRequest(context.Background(), "POST", "events.v1", map[string]string{"foo": "bar", "lol": "beans"})
+	req := NewRequest("POST", "events.v1", map[string]string{"foo": "bar", "lol": "beans"})
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(context.Background(), req)
 
 	if assert.Nil(t, err) {
 		assert.Equal(t, 200, resp.StatusCode)
@@ -187,9 +187,9 @@ func TestDo_get(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	req := NewRequest(context.Background(), "GET", "events.v1", nil)
+	req := NewRequest("GET", "events.v1", nil)
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(context.Background(), req)
 
 	if assert.Nil(t, err) {
 		assert.Equal(t, 200, resp.StatusCode)
@@ -204,9 +204,9 @@ func TestDo_with_bad_base_url(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	req := NewRequest(context.Background(), "GET", "events.v1", nil)
+	req := NewRequest("GET", "events.v1", nil)
 
-	_, err := client.Do(req)
+	_, err := client.Do(context.Background(), req)
 
 	assert.NotNil(t, err)
 }
@@ -225,9 +225,9 @@ func TestDo_with_header_issues(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	req := NewRequest(context.Background(), "GET", "events.v1", nil)
+	req := NewRequest("GET", "events.v1", nil)
 
-	_, err := client.Do(req)
+	_, err := client.Do(context.Background(), req)
 
 	assert.NotNil(t, err)
 }
@@ -247,9 +247,9 @@ func TestDo_post_with_unmarshalable_body(t *testing.T) {
 
 	client := NewClient(config)
 	// func cannot be marshalled
-	req := NewRequest(context.Background(), "POST", "events.v1", func() { t.Fatal("this should not run") })
+	req := NewRequest("POST", "events.v1", func() { t.Fatal("this should not run") })
 
-	_, err := client.Do(req)
+	_, err := client.Do(context.Background(), req)
 
 	assert.NotNil(t, err)
 }
@@ -269,9 +269,9 @@ func TestDo_unrequestable_request(t *testing.T) {
 
 	client := NewClient(config)
 	// unicode in the method is a nono
-	req := NewRequest(context.Background(), "£££££", "events.v1", nil)
+	req := NewRequest("£££££", "events.v1", nil)
 
-	_, err := client.Do(req)
+	_, err := client.Do(context.Background(), req)
 
 	assert.NotNil(t, err)
 }
@@ -286,9 +286,9 @@ func TestDo_error_when_doing(t *testing.T) {
 	}
 
 	client := NewClient(config)
-	req := NewRequest(context.Background(), "POST", "events.v1", nil)
+	req := NewRequest("POST", "events.v1", nil)
 
-	_, err := client.Do(req)
+	_, err := client.Do(context.Background(), req)
 
 	assert.NotNil(t, err)
 }

--- a/example/main.go
+++ b/example/main.go
@@ -1,42 +1,64 @@
 package main
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	log "github.com/sirupsen/logrus"
+	"go.opencensus.io/exporter/jaeger"
+	"go.opencensus.io/plugin/ochttp"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/trace"
 
+	"github.com/ingresso-group/expedia-api-adapter/utils"
 	ticketswitch "github.com/ingresso-group/goticketswitch.v2"
 )
 
 func main() {
+	setupTracing()
+
 	config := ticketswitch.NewConfig("demo", "demopass")
 	client := ticketswitch.NewClient(config)
+
+	// Add opencensus tracing to the http client Transport (aka RoundTripper interface)
+	client.HTTPClient.Transport = &ochttp.Transport{}
+	ctx, span := trace.StartSpan(context.Background(), "Main")
+	defer span.End()
 	params := ticketswitch.GetAvailabilityParams{
 		NumberOfSeats: 2,
 	}
-	//params.CostRange = true
-	results, err := client.GetAvailability("7AB-6", &params)
+
+	ctx, innerSpan := trace.StartSpan(ctx, "GetAvailability")
+	results, err := client.GetAvailability(ctx, "7AB-6", &params)
+	innerSpan.End()
 	fmt.Println("\n\nAVAILABILITY:")
 	if err != nil {
 		log.Fatal(err)
 	}
 	log.Printf("%+v", results)
 
-	discountsResults, err := client.GetDiscounts("6IF-C5O", "CIRCLE", "A/pool", nil)
+	ctx, innerSpan = trace.StartSpan(ctx, "GetDiscounts")
+	discountsResults, err := client.GetDiscounts(ctx, "6IF-C5O", "CIRCLE", "A/pool", nil)
+	innerSpan.End()
 	fmt.Println("\n\ndiscountsResults:")
 	if err != nil {
 		log.Fatal(err)
 	}
 	log.Printf("%+v", discountsResults)
 
-	sources, err := client.GetSources(nil)
+	ctx, innerSpan = trace.StartSpan(ctx, "GetSources")
+	sources, err := client.GetSources(nil, nil)
+	innerSpan.End()
 	fmt.Println("\n\nSOURCES:")
 	if err != nil {
 		log.Fatal(err)
 	}
 	log.Printf("%+v", sources)
 
-	sendMethods, err := client.GetSendMethods("7AB-5", nil)
+	ctx, innerSpan = trace.StartSpan(ctx, "GetSendMethods")
+	sendMethods, err := client.GetSendMethods(nil, "7AB-5", nil)
+	innerSpan.End()
 	fmt.Println("\n\nSEND METHODS:")
 	if err != nil {
 		log.Fatal(err)
@@ -52,7 +74,9 @@ func main() {
 		SourceCode:     sendMethods.SourceCode,
 		SendMethod:     sendMethods.SendMethodsHolder.SendMethods[1].Code,
 	}
-	reservation, err := client.MakeReservation(reserveParams)
+	ctx, innerSpan = trace.StartSpan(ctx, "MakeReservation")
+	reservation, err := client.MakeReservation(nil, reserveParams)
+	innerSpan.End()
 	fmt.Println("\n\nRESERVATION:")
 	if err != nil {
 		log.Fatal(err)
@@ -60,17 +84,45 @@ func main() {
 	log.Printf("%+v", reservation)
 
 	transactionParams := ticketswitch.TransactionParams{TransactionUUID: reservation.Trolley.TransactionUUID}
-	status, err := client.GetStatus(&transactionParams)
+	ctx, innerSpan = trace.StartSpan(ctx, "GetStatus")
+	status, err := client.GetStatus(nil, &transactionParams)
+	innerSpan.End()
 	fmt.Println("\n\nSTATUS:")
 	if err != nil {
 		fmt.Println(err)
 	}
 	log.Printf("%+v", status)
 
-	success, err := client.ReleaseReservation(&transactionParams)
+	ctx, innerSpan = trace.StartSpan(ctx, "ReleaseReservation")
+	success, err := client.ReleaseReservation(nil, &transactionParams)
+	innerSpan.End()
 	fmt.Println("\n\nRELEASE:")
 	if err != nil {
 		fmt.Println(err)
 	}
 	log.Printf("%+v", success)
+}
+
+// setupTracing is an example of how to set up tracing using opencensus.
+// There are of course many ways to do this.
+// You can run jaeger locally using the docker run command found here:
+// https://www.jaegertracing.io/docs/getting-started/
+func setupTracing() {
+	// Register stats and trace exporters to export the collected data.
+	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+
+	// Tracing exporter via Jaeger
+	jaegerHost := utils.GetEnv("JAEGER_ADDR", "http://localhost:14268")
+	jeagerExporter, err := jaeger.NewExporter(jaeger.Options{
+		Endpoint:    jaegerHost,
+		ServiceName: "ticketswitcher",
+	})
+	if err != nil {
+		log.Error(err)
+	}
+	defer jeagerExporter.Flush()
+	trace.RegisterExporter(jeagerExporter)
+
+	// Report stats at every second.
+	view.SetReportingPeriod(1 * time.Second)
 }

--- a/example/main.go
+++ b/example/main.go
@@ -11,7 +11,6 @@ import (
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
 
-	"github.com/ingresso-group/expedia-api-adapter/utils"
 	ticketswitch "github.com/ingresso-group/goticketswitch.v2"
 )
 
@@ -112,7 +111,7 @@ func setupTracing() {
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 
 	// Tracing exporter via Jaeger
-	jaegerHost := utils.GetEnv("JAEGER_ADDR", "http://localhost:14268")
+	jaegerHost := "http://localhost:14268"
 	jeagerExporter, err := jaeger.NewExporter(jaeger.Options{
 		Endpoint:    jaegerHost,
 		ServiceName: "ticketswitcher",

--- a/media.go
+++ b/media.go
@@ -5,7 +5,7 @@ type Media struct {
 	// caption in plain text describing the asset.
 	Caption string
 	// caption as html describing the asset.
-	Caption_html string
+	CaptionHTML string
 	// name of the asset.
 	Name string
 	// url for the asset.

--- a/request.go
+++ b/request.go
@@ -1,6 +1,7 @@
 package ticketswitch
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 )
@@ -14,6 +15,7 @@ type Request struct {
 	Body     interface{}
 	Puzzled  bool
 	LogRaw   bool
+	Context  context.Context
 }
 
 // NewRequest returns a pointer to a new created Request

--- a/request.go
+++ b/request.go
@@ -19,13 +19,14 @@ type Request struct {
 }
 
 // NewRequest returns a pointer to a new created Request
-func NewRequest(method, endpoint string, body interface{}) *Request {
+func NewRequest(ctx context.Context, method, endpoint string, body interface{}) *Request {
 	r := Request{
 		Method:   method,
 		Endpoint: endpoint,
 		Header:   make(http.Header),
 		Values:   make(url.Values),
 		Body:     body,
+		Context:  ctx,
 	}
 
 	return &r

--- a/request.go
+++ b/request.go
@@ -1,7 +1,6 @@
 package ticketswitch
 
 import (
-	"context"
 	"net/http"
 	"net/url"
 )
@@ -15,18 +14,16 @@ type Request struct {
 	Body     interface{}
 	Puzzled  bool
 	LogRaw   bool
-	Context  context.Context
 }
 
 // NewRequest returns a pointer to a new created Request
-func NewRequest(ctx context.Context, method, endpoint string, body interface{}) *Request {
+func NewRequest(method, endpoint string, body interface{}) *Request {
 	r := Request{
 		Method:   method,
 		Endpoint: endpoint,
 		Header:   make(http.Header),
 		Values:   make(url.Values),
 		Body:     body,
-		Context:  ctx,
 	}
 
 	return &r


### PR DESCRIPTION
I know @nicwest doesn't like tracing within goticketswitch and I know that @Dev25 likes tracing within goticketswitch. The branch instrument: https://github.com/ingresso-group/goticketswitch.v2/tree/instrument has opencensus spans which lock the user into using opencensus and it has an interface for the client (which is not where it should really be put). What I've done here is to compromise. These changes add contexts but the tracing is all done externally. See example/main.go for an example which includes tracing.