### PR TITLE
Added callback gone and authentication errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.0.2] - 2019-01-16
+### Added
+- Check for Callback Gone and Authentication errors
+
 ## [1.0.1] - 2018-08-24
 ### Fixed
 - Close the response body after we're done with it
@@ -36,4 +40,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - exposed DateRange utility
 
-[Unreleased]: https://github.com/ingresso-group/goticketswitch.v2/compare/1.0.1...HEAD
+[Unreleased]: https://github.com/ingresso-group/goticketswitch.v2/compare/1.0.2...HEAD

--- a/error.go
+++ b/error.go
@@ -6,6 +6,9 @@ import (
 	"net/http"
 )
 
+// F13AuthErrorCode is the error code that gets returned for Authentication errors
+const F13AuthErrorCode int = 3
+
 // Error represents an error returned by the API
 type Error struct {
 	Code                int    `json:"error_code"`
@@ -29,7 +32,7 @@ func checkForError(resp *http.Response) error {
 		return err
 	}
 
-	if ret.Code == 3 {
+	if ret.Code == F13AuthErrorCode {
 		ret.AuthenticationError = true
 	}
 	if ret.Code > 0 || ret.Description != "" || ret.AuthenticationError || ret.CallbackGoneError {


### PR DESCRIPTION
Add a check for callback gone error and authentication error to the error that gets returned. This aligns the behaviour more with pyticketswitch.